### PR TITLE
unpack functions and fix warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
   'targets': [
     {
       'target_name': 'addon-layer',
+      'cflags': [ '-Wall', '-Werror' ],
       'type': 'static_library',
       'include_dirs': [ 'include' ],
       'sources': [

--- a/include/shim.h
+++ b/include/shim.h
@@ -342,7 +342,7 @@ size_t shim_string_length(shim_val_t* val);
 size_t shim_string_length_utf8(shim_val_t* val);
 
 /** Get the value of the string */
-const char* shim_string_value(shim_val_t* val);
+char* shim_string_value(shim_val_t* val);
 /* TODO enum for options */
 /** Write the value of the string to a buffer */
 size_t shim_string_write_ascii(shim_val_t* val, char* buff, size_t start,

--- a/include/shim.h
+++ b/include/shim.h
@@ -76,8 +76,6 @@ typedef int shim_bool_t;
 
 /** Entry point from node to register the addon layer */
 typedef void (* node_register_func)(void*, void*);
-/** The declaration of the addon layer entry point */
-void shim_module_initialize(void*, void*);
 
 /** Signature of for how a module will be initialized */
 typedef int (* register_func)(shim_ctx_t*, shim_val_t*, shim_val_t*);
@@ -123,9 +121,10 @@ struct shim_module_struct name ## _module = {                                 \
   SHIM_NODE_ABI,                                                              \
   NULL,                                                                       \
   __FILE__,                                                                   \
-  (node_register_func)&shim_module_initialize,                                \
+  NULL,									      \
   #name,                                                                      \
-};
+};									      \
+const char* shim_modname = # name ;
 
 /** The signature of the entry point for exported functions */
 typedef int (* shim_func)(shim_ctx_t*, shim_args_t*);

--- a/include/shim.h
+++ b/include/shim.h
@@ -172,7 +172,9 @@ shim_bool_t shim_value_to(shim_ctx_t* ctx, shim_val_t* val, shim_type_t type,
   shim_val_t* rval);
 
 
-/** Relase memory associated with this value */
+/** Allocate memory to hold an arbitrary value. */
+shim_val_t *shim_value_alloc(void);
+/** Release memory associated with this value */
 void shim_value_release(shim_val_t* val);
 
 /** Get the undefined value */

--- a/include/shim.h
+++ b/include/shim.h
@@ -30,6 +30,7 @@ extern "C" {
 
 #include "stdint.h"
 #include "node_version.h"
+#include <stddef.h>
 
 /**
  * \defgroup core Core types and helpers

--- a/src/shim.cc
+++ b/src/shim.cc
@@ -24,6 +24,8 @@
 #include <cstdarg>
 #include <cstdlib>
 #include <cstring>
+
+#include <strings.h>
 #include <dlfcn.h>
 
 #include "shim.h"
@@ -526,6 +528,19 @@ shim_val_t*
 shim_null()
 {
   return &shim__null;
+}
+
+/**
+ * \sa [memory](md_docs_memory.html)
+ *
+ * Allocate memory to hold an arbitrary handle.
+ */
+shim_val_t*
+shim_value_alloc(void)
+{
+	shim_val_t *val = (shim_val_t *)malloc(sizeof (shim_val_t));
+	bzero(val, sizeof (*val));
+	return (val);
 }
 
 /**

--- a/src/shim.cc
+++ b/src/shim.cc
@@ -941,8 +941,9 @@ shim_func_call_sym(shim_ctx_t* ctx, shim_val_t* self, shim_val_t* sym,
   Local<Object> recv = OBJ_TO_OBJECT(SHIM_TO_VAL(self));
 
   Local<String> str = OBJ_TO_STRING(SHIM_TO_VAL(sym));
-
-  rval->handle = *shim_call_func(recv, str, argc, argv);
+  Handle<Value> ret = shim_call_func(recv, str, argc, argv);
+  if (rval != NULL)
+          rval->handle = *ret;
 
   TryCatch *tr = static_cast<TryCatch*>(ctx->trycatch);
   return !tr->HasCaught();
@@ -964,8 +965,10 @@ shim_func_call_name(shim_ctx_t* ctx, shim_val_t* self, const char* name,
   assert(self != NULL);
   Local<Object> recv = OBJ_TO_OBJECT(SHIM_TO_VAL(self));
 
-  rval->handle = *shim_call_func(recv, String::NewSymbol(name), argc, argv);
-  
+  Handle<Value> ret = shim_call_func(recv, String::NewSymbol(name), argc, argv);
+  if (rval != NULL)
+          rval->handle = *ret;
+
   TryCatch *tr = static_cast<TryCatch*>(ctx->trycatch);
   return !tr->HasCaught();
 }
@@ -994,7 +997,9 @@ shim_func_call_val(shim_ctx_t* ctx, shim_val_t* self, shim_val_t* func,
   else
     recv = Object::New();
 
-  rval->handle = *shim_call_func(recv, fn, argc, argv);
+  Handle<Value> ret = shim_call_func(recv, fn, argc, argv);
+  if (rval != NULL)
+          rval->handle = *ret;
 
   TryCatch *tr = static_cast<TryCatch*>(ctx->trycatch);
   return !tr->HasCaught();
@@ -1020,7 +1025,9 @@ shim_make_callback_sym(shim_ctx_t* ctx, shim_val_t* self, shim_val_t* sym,
 
   Local<Value>* jsargs = shim_vals_to_handles(argc, argv);
 
-  rval->handle = *node::MakeCallback(recv, jsym, argc, jsargs);
+  Handle<Value> ret = node::MakeCallback(recv, jsym, argc, jsargs);
+  if (rval != NULL)
+          rval->handle = *ret;
 
   delete jsargs;
 
@@ -1055,8 +1062,8 @@ shim_make_callback_val(shim_ctx_t* ctx, shim_val_t* self, shim_val_t* fval,
   }
 
   Handle<Value> ret = node::MakeCallback(recv, fn, argc, jsargs);
-
-  rval->handle = *ret;
+  if (rval != NULL)
+          rval->handle = *ret;
 
   delete jsargs;
 
@@ -1083,8 +1090,8 @@ shim_make_callback_name(shim_ctx_t* ctx, shim_val_t* obj, const char* name,
   Local<Object> recv = OBJ_TO_OBJECT(SHIM_TO_VAL(obj));
 
   Handle<Value> ret = node::MakeCallback(recv, name, argc, jsargs);
-
-  rval->handle = *ret;
+  if (rval != NULL)
+          rval->handle = *ret;
 
   delete jsargs;
 

--- a/src/shim.cc
+++ b/src/shim.cc
@@ -1231,7 +1231,7 @@ shim_string_length_utf8(shim_val_t* val)
  *
  * The caller is responsible for free'ing this memory
  */
-const char*
+char*
 shim_string_value(shim_val_t* val)
 {
   String::Utf8Value str(OBJ_TO_STRING(SHIM_TO_VAL(val)));

--- a/src/shim.cc
+++ b/src/shim.cc
@@ -1588,13 +1588,17 @@ shim_unpack_type(shim_ctx_t* ctx, shim_val_t* arg, shim_type_t type,
       break;
     case SHIM_TYPE_STRING:
       vrval->handle = *OBJ_TO_STRING(val);
+      vrval->type = SHIM_TYPE_STRING;
+      break;
+    case SHIM_TYPE_FUNCTION:
+      vrval->handle = *val;
+      vrval->type = SHIM_TYPE_FUNCTION;
       break;
     case SHIM_TYPE_UNDEFINED:
     case SHIM_TYPE_NULL:
     case SHIM_TYPE_DATE:
     case SHIM_TYPE_ARRAY:
     case SHIM_TYPE_OBJECT:
-    case SHIM_TYPE_FUNCTION:
     default:
       return FALSE;
       break;


### PR DESCRIPTION
This PR does a few things:
- Adds the ability to unpack a value of type SHIM_TYPE_FUNCTION.
- Fixes a case where unpacking a string wouldn't set the type.  I think the intent was to initialize the type lazily, which is fine -- as long as the caller always initialized it to SHIM_TYPE_UNKNOWN to begin with.  But they don't necessarily, and you can have a shim_val that thinks it's the wrong type.
- Enables all warnings and makes them errors.
- Fixes a warning about the definition of shim_module_initialize() not matching the declaration.  This was tricky because it's used in the definition of the struct that makes up the Node add-on interface, so it's determined by Node that this be a C++ function.  But the point of the shim is to allow the add-on to be pure C.  The solution used here is to have the C add-on's definition fill in NULL for the pointer, and use an "init" function (that runs when the add-on is dlopen'ed) to fill in the correct value.
- Removes a warning about unused local variables by breaking up the SHIM_PROLOGUE() macro.  This one's unsatisfying, but I think it's worth it to compile without warnings.
- Adds a #include of stddef.h in the header file for the size_t type used in the header.
- Changes shim_string_value to return "char *" instead of "const char *" (since you can't free a "const char *")
- Allow you to omit the "rval" parameter when invoking a function (to ignore the return value)
- Add a public function to allocate a shim value, since there's no other way to allocate an appropriately-sized chunk
