### PR TITLE
Patches in the short term compatibility with <0.11.10

### DIFF
--- a/include/shim.h
+++ b/include/shim.h
@@ -188,7 +188,8 @@ SHIM_C_CTOR(name ## _module_register) {                                       \
 #else
 #define SHIM_MODULE(name, func)                                               \
 register_func shim_initialize = &func;                                        \
-struct shim_module_struct name ## _module = SHIM_MODULE_INIT(name)
+struct shim_module_struct name ## _module = SHIM_MODULE_INIT(name)            \
+const char* shim_modname = # name ;
 #endif
 
 /** The signature of the entry point for exported functions */

--- a/src/shim.cc
+++ b/src/shim.cc
@@ -1922,6 +1922,23 @@ shim_type_str(shim_type_t type)
   return ("INVALID_TYPE");
 }
 
+#if !NODE_VERSION_AT_LEAST(0, 11, 10)
+
+#include <strings.h>
+#include <dlfcn.h>
+
+__attribute__((constructor)) void shim_module_preinit(void)
+{
+   struct shim_module_struct *module;
+   char namebuf[256];
+ 
+   (void) snprintf(namebuf, sizeof (namebuf), "%s_module", shim_modname);
+   module = (struct shim_module_struct *)dlsym(RTLD_SELF, namebuf);
+   module->func = (node_register_func)shim_module_initialize;
+}
+
+#endif
+
 
 } /* extern "C" */
 


### PR DESCRIPTION
This is a slight rollback of the last rollback, but 0.10.18 fails with HEAD of node-addon-layer. This reverts the relevant parts for 0.10 in the short term until there's time to fix it (or I suppose drop 0.10 support).
